### PR TITLE
[DOC] Correct link to project on pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-home-page = "https://github.com/executablebooks/sphinx_autobuild"
+home-page = "https://github.com/executablebooks/sphinx-autobuild"
 license = "MIT"
 requires-python = ">=3.6"
 requires = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-home-page = "https://github.com/GaretJax/sphinx_autobuild"
+home-page = "https://github.com/executablebooks/sphinx_autobuild"
 license = "MIT"
 requires-python = ">=3.6"
 requires = [


### PR DESCRIPTION
I'm assuming the project/repository was transferred here, but the link that is still published on pypi.org returns a 404.