### PR TITLE
Option to launch the server at a specific file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ optional arguments:
   --port PORT           port to serve documentation on. 0 means find and use a free port (default: 8000)
   --host HOST           hostname to serve documentation on (default: 127.0.0.1)
   --re-ignore RE_IGNORE
+  --launch FILE         sets the file to launch the browser too
                         regular expression for files to ignore, when watching for changes (default: [])
   --ignore IGNORE       glob expression for files to ignore, when watching for changes (default: [])
   --no-initial          skip the initial build (default: False)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ optional arguments:
   --port PORT           port to serve documentation on. 0 means find and use a free port (default: 8000)
   --host HOST           hostname to serve documentation on (default: 127.0.0.1)
   --re-ignore RE_IGNORE
-  --launch FILE         sets the file to launch the browser too
+  --launch FILE         sets the file to launch the browser to
                         regular expression for files to ignore, when watching for changes (default: [])
   --ignore IGNORE       glob expression for files to ignore, when watching for changes (default: [])
   --no-initial          skip the initial build (default: False)

--- a/src/sphinx_autobuild/cli.py
+++ b/src/sphinx_autobuild/cli.py
@@ -124,6 +124,12 @@ def get_parser():
     parser.add_argument(
         "--version", action="version", version="sphinx-autobuild {}".format(__version__)
     )
+    parser.add_argument(
+        "--launch",
+        metavar="FILE",
+        type=str,
+        help="Specify filename to launch browser to",
+    )
 
     sphinx_arguments = ", ".join(
         f"-{arg}" if meta is None else f"-{arg}={meta}"
@@ -185,6 +191,14 @@ def main():
     # Find the free port
     portn = args.port or find_free_port()
     if args.openbrowser is True:
-        server.serve(port=portn, host=args.host, root=outdir, open_url_delay=args.delay)
+        server.serve(
+            port=portn,
+            host=args.host,
+            root=outdir,
+            open_url_delay=args.delay,
+            default_filename=args.launch,
+        )
     else:
-        server.serve(port=portn, host=args.host, root=outdir)
+        server.serve(
+            port=portn, host=args.host, root=outdir, default_filename=args.launch
+        )


### PR DESCRIPTION
A quick suggestion for the issue I posted earlier:

https://github.com/executablebooks/sphinx-autobuild/issues/100

Got an error while trying to run the `nox -s tests` command, so couldn't test this:
```
nox > Error while collecting sessions.
nox > Sessions not found: tests
```
lints passed successfully.
Tested the update using:
`nox -s docs-live "--" --launch index.html`
and by moving the index to a subfolder, then running:
`nox -s docs-live "--" --launch subdir/index.html -D master_doc=subdir/index`
the link directly connected to index.html as expected.