### PR TITLE
Travis-ci:added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,29 @@ python: 3.8
 matrix:
   include:
     - env: NOXSESSION=docs
+      arch: amd64
     - env: NOXSESSION=lint
+      arch: amd64
     - python: 3.6
       env: NOXSESSION=test-3.6
+      arch: amd64
     - python: 3.7
       env: NOXSESSION=test-3.7
+      arch: amd64
     - python: 3.8
       env: NOXSESSION=test-3.8
+      arch: amd64
+    - env: NOXSESSION=docs
+      arch: ppc64le
+    - python: 3.6
+      env: NOXSESSION=test-3.6
+      arch: ppc64le
+    - python: 3.7
+      env: NOXSESSION=test-3.7
+      arch: ppc64le
+    - python: 3.8
+      env: NOXSESSION=test-3.8
+      arch: ppc64le
 
 install: pip install nox
 script: nox


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch on behalf of IBM. The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/sphinx-autobuild/builds/209614746 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!