### PR TITLE
ENH: Allow passing relative paths to --ignore

### DIFF
--- a/src/sphinx_autobuild/cli.py
+++ b/src/sphinx_autobuild/cli.py
@@ -36,7 +36,7 @@ def _get_build_args(args):
 
 
 def _get_ignore_handler(args):
-    regular = args.ignore[:]
+    regular = [os.path.realpath(path) for path in args.ignore[:]]
     regular.append(os.path.realpath(args.outdir))  # output directory
     if args.w:  # Logfile
         regular.append(os.path.realpath(args.w[0]))


### PR DESCRIPTION
For the longest time I've wondered why sphinx-autobuild would get stuck
in an infinite rebuild loop, even though I'd ignored the directories I
needed too. Turns out, --ignore only worked with absolute paths, which
seems like an odd thing to work for anyone.

This allows either relative or absolute paths, and passes globs through
unharmed.