### PR TITLE
Fix typo in pokemon name

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ When working on multiple Sphinx documentation projects simultaneously, it is req
 
 ```
 sphinx-autobuild --port=0 --open-browser pikachu/docs pikachu/docs/_build/html &
-sphinx-autobuild --port=0 --open-browser magickarp/docs magickarp/docs/_build/html &
+sphinx-autobuild --port=0 --open-browser magikarp/docs magickarp/docs/_build/html &
 ```
 
 ## Relevant Sphinx Bugs


### PR DESCRIPTION
https://www.pokemon.com/us/pokedex/magikarp