### PR TITLE
Add Sphinx PyPi classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
-  "Framework :: Sphinx :: Extension",
+  "Framework :: Sphinx",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
+  "Framework :: Sphinx :: Extension",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",


### PR DESCRIPTION
Add the Sphinx PyPi classifier so that the package shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx).