### PR TITLE
[ENH] Sphinx's `exclude_patterns` as ignore patterns

### DIFF
--- a/src/sphinx_autobuild/cli.py
+++ b/src/sphinx_autobuild/cli.py
@@ -44,6 +44,21 @@ def _get_ignore_handler(args):
         regular.append(os.path.realpath(args.d[0]))
 
     regex_based = args.re_ignore
+
+    try:
+        import types
+        from importlib.machinery import SourceFileLoader
+
+        confPath = os.path.join(args.sourcedir, "conf.py")
+        confLoader = SourceFileLoader("conf", confPath)
+        conf = types.ModuleType(confLoader.name)
+        confLoader.exec_module(conf)
+        regular = regular + conf.exclude_patterns
+    except Exception as e:
+        # if either conf.py or exclude_patterns are invalid,
+        # simply defer error reporting to sphinx-build
+        pass
+
     return get_ignore(regular, regex_based)
 
 

--- a/src/sphinx_autobuild/cli.py
+++ b/src/sphinx_autobuild/cli.py
@@ -49,11 +49,12 @@ def _get_ignore_handler(args):
         import types
         from importlib.machinery import SourceFileLoader
 
-        confPath = os.path.join(args.sourcedir, "conf.py")
-        confLoader = SourceFileLoader("conf", confPath)
-        conf = types.ModuleType(confLoader.name)
-        confLoader.exec_module(conf)
-        regular = regular + conf.exclude_patterns
+        conf_path = os.path.join(args.sourcedir, "conf.py")
+        conf_loader = SourceFileLoader("conf", conf_path)
+        conf = types.ModuleType(conf_loader.name)
+        conf_loader.exec_module(conf)
+        conf_regular = [os.path.realpath(path) for path in conf.exclude_patterns]
+        regular = regular + conf_regular
     except Exception as e:
         # if either conf.py or exclude_patterns are invalid,
         # simply defer error reporting to sphinx-build

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,55 @@
+from argparse import Namespace
+from unittest import mock
+import tempfile
+import os
+
+
+def test__get_ignore_handler():
+    args_ignore = ["ignore.pyc"]
+    args_re_ignore = ["^REGEX1$", "^REGEX2$"]
+
+    with mock.patch("sphinx_autobuild.ignore.get_ignore") as mock_get_ignore:
+        from sphinx_autobuild.cli import _get_ignore_handler
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            args = Namespace(
+                sourcedir=tmpdir,
+                outdir="output/directory",
+                ignore=args_ignore,
+                re_ignore=args_re_ignore,
+                w=['error.log'],
+                d=['doctrees-cache'],
+            )
+
+            # without conf.py
+            _get_ignore_handler(args)
+
+            expected_ignore = [
+                os.path.realpath("ignore.pyc"),
+                os.path.realpath("output/directory"),
+                os.path.realpath("error.log"),
+                os.path.realpath("doctrees-cache"),
+            ]
+            expected_re_ignore = args_re_ignore
+
+            mock_get_ignore.assert_called_once_with(expected_ignore, expected_re_ignore)
+
+            mock_get_ignore.reset_mock()
+
+            # with conf.py
+            with open(os.path.join(tmpdir, "conf.py"), mode="w") as f:
+                f.write("exclude_patterns = ['drafts/*.rst', 'drafts/*.md']")
+
+            _get_ignore_handler(args)
+
+            expected_ignore = [
+                os.path.realpath("ignore.pyc"),
+                os.path.realpath("output/directory"),
+                os.path.realpath("error.log"),
+                os.path.realpath("doctrees-cache"),
+                os.path.realpath("drafts/*.rst"),
+                os.path.realpath("drafts/*.md"),
+            ]
+            expected_re_ignore = args_re_ignore
+
+            mock_get_ignore.assert_called_once_with(expected_ignore, expected_re_ignore)


### PR DESCRIPTION
Hi :) This is an implementation for the feature requested in issue #131 

This fork enables sphinx-autobuild's ignore system to leverage sphinx's `conf.py`.
Sphinx's `exclude_patterns` configuration is now taken into account when determining what files to ignore.

P.S: I know my try statement looks a little paranoid but I feel it's adequate given the circumstances.
Anyway, let me know your thoughts.

P.P.S: Sorry I couldn't run the linter ¯\_(ツ)_/¯ (but I did run the code through Black)