### PR TITLE
Docs update to reflect sphinx progress on #34

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for being interested in contributing to the `sphinx-autobuild`! You
 are awesome. :sparkles:
 
-See the [EBP Contributing Guide](https://executablebooks.org/en/latest/contributing.html) for general details,
+See the [EBP Contributing Guide](https://executablebooks.org/en/latest/contribute/) for general details,
 then this page contains information to help you get started with development on this project.
 
 ## Feature Suggestions

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ sphinx-autobuild --port=0 --open-browser magikarp/docs magickarp/docs/_build/htm
 
 ## Relevant Sphinx Bugs
 
-Sphinx does not [detect changes in non-document files in incremental mode](https://github.com/GaretJax/sphinx-autobuild/issues/34), like theme files, static files and source code used with autodoc.
+Sphinx does not [detect changes in non-document, non-code files in incremental mode](https://github.com/GaretJax/sphinx-autobuild/issues/34), like theme files and static files.
 
 At the time of writing, the only known workaround is to instruct Sphinx to rebuild the relevant pages. This can be done by disabling incremental mode (with `-a`) or passing relevant `filenames` in addition to source and output directory in the CLI.
 


### PR DESCRIPTION
It appears that the underlying issue in sphinx causing #34 (live reloading not working for autodoc'd code files and other static files) is at partially fixed. I get automatic rebuilds and browser reloads when I update my code files (as long as the directory they're in is watched). Still no reloads for other static files, but the code files were the biggest pain point since that's where most of the docs live for many of us using autodoc.

This PR updates the README "sphinx bugs" section accordingly. I also fixed a dead link to the EBP contributing guide.